### PR TITLE
Take out ECG in VHDR file with dataimport.m

### DIFF
--- a/dataimport.m
+++ b/dataimport.m
@@ -68,6 +68,8 @@ switch datatype
         EEG = pop_fileio(fullfile);
         fprintf('Loading default channel locations.');
         EEG = pop_chanedit(EEG, 'lookup', which('standard-10-5-cap385.elp'));
+        fprintf('Checking for additional channels.'); 
+        EEG = pop_select(EEG,'nochannel',{'ECG'});
     otherwise
         error('Unsupported filetype %s.',datatype);
 end


### PR DESCRIPTION
In VHDR files, additional channels (such as ECG) are saved in the same file. Thus, with this change (line 72) we ensure that we don't consider it as a "brain electrode"

In the future, other "channels" recording physiological data (such as respiration) should be taken out. 

Note that I have not done it on (current) line 81 "%REMOVE PERIPHERAL CHANNELS" as this is specific for the VHDR format and the numbers of the channels can be wrongly considered (with our 127 electrodes + ECG, nbchan was equal to 128).